### PR TITLE
chore: fix build error because of `calendar-link` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@fontsource/ibm-plex-sans": "^4.5.5",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
-        "calendar-link": "^2.2.0",
+        "dayjs": "1.11.6",
+        "query-string": "7.1.1",
         "svelte-fa": "^2.4.0",
         "svelte-loading-spinners": "0.1.7"
       },
@@ -1702,15 +1703,6 @@
         "node": "*"
       }
     },
-    "node_modules/calendar-link": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/calendar-link/-/calendar-link-2.2.0.tgz",
-      "integrity": "sha512-Q9HDfz+pMKGGPJ9RJPtt38ucl4cfm0FvrKGi+SrNTjHZgfKAQcbnsk9fVc80kGgKaagIztYacl+hqVoP7zPWvw==",
-      "dependencies": {
-        "dayjs": "^1.9.3",
-        "query-string": "^6.13.6"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1853,9 +1845,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -4434,9 +4426,9 @@
       }
     },
     "node_modules/query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -6577,15 +6569,6 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
-    "calendar-link": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/calendar-link/-/calendar-link-2.2.0.tgz",
-      "integrity": "sha512-Q9HDfz+pMKGGPJ9RJPtt38ucl4cfm0FvrKGi+SrNTjHZgfKAQcbnsk9fVc80kGgKaagIztYacl+hqVoP7zPWvw==",
-      "requires": {
-        "dayjs": "^1.9.3",
-        "query-string": "^6.13.6"
-      }
-    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -6695,9 +6678,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "debug": {
       "version": "4.3.3",
@@ -8527,9 +8510,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   },
   "dependencies": {
     "@fontsource/ibm-plex-sans": "^4.5.5",
-    "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
-    "calendar-link": "^2.2.0",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "dayjs": "1.11.6",
+    "query-string": "7.1.1",
     "svelte-fa": "^2.4.0",
     "svelte-loading-spinners": "0.1.7"
   },

--- a/src/components/Talk.svelte
+++ b/src/components/Talk.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { google as getGoogleCalendarLink } from "calendar-link";
+  import { getGoogleCalendarLink } from '../utils/calendar';
   import SocialLinks from './SocialLinks.svelte'
   import type { SocialLink } from './SocialLinks.svelte'
 
@@ -14,7 +14,7 @@
   const googleCalendarLink = getGoogleCalendarLink({
     title: `[GambiConf Talk] ${talkTitle}`,
     start: `${date} ${hours}:00 +0100`,
-    duration: [duration, 'minutes'],
+    duration,
   })
 </script>
 

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -1,0 +1,25 @@
+import dayjs from 'dayjs';
+import { stringify } from 'query-string';
+
+type CalendarEventParams = {
+  title: string
+  start: string
+  duration: number
+}
+
+const getGoogleCalendarLink = ({ start, duration, title }: CalendarEventParams) => {
+  const startUtc = dayjs(start)
+
+  const startDate = startUtc.format('YYYYMMDDTHHmmssZ')
+  const endDate = startUtc.add(duration, 'minutes').format('YYYYMMDDTHHmmssZ')
+
+  const details = {
+    action: 'TEMPLATE',
+    text: title,
+    dates: `${startDate}/${endDate}`,
+  };
+
+  return `https://calendar.google.com/calendar/render?${stringify(details)}`
+}
+
+export { getGoogleCalendarLink }


### PR DESCRIPTION
Restore PR https://github.com/gambiconf/gambiconf.github.io/pull/10

Currently, the production build fails because of an error on `calendar-link`.
This PR fixes it by replacing this dependency with a built-in code.

Co-authored-by: Ana Bastos <hello@anabastos.me>