### PR TITLE
Add prettier to CI/CD pipeline

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,15 @@
+name: Prettier
+
+on: push
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.2
+        with:
+          prettier_options: --config .prettierrc

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --config .prettierrc .
+          prettier_options: --config .prettierrc --check .

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,4 +12,5 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
+          prettier_plugins: 'prettier-plugin-svelte'
           prettier_options: --config .prettierrc --check .

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,3 +14,4 @@ jobs:
         with:
           prettier_plugins: "prettier-plugin-svelte"
           prettier_options: --config .prettierrc --check .
+          dry: true

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --config .prettierrc
+          prettier_options: --config .prettierrc .

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_plugins: 'prettier-plugin-svelte'
+          prettier_plugins: "prettier-plugin-svelte"
           prettier_options: --config .prettierrc --check .

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -10,6 +10,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Prettify code
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --config .prettierrc


### PR DESCRIPTION
After deciding the configurations for the `prettier` command in the #15, this PR adds a CI/CD step to check if the commits are following the code style defined in the `.prettierrc` file.