### PR TITLE
Add support to OG/Twitter embeds 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Deploying to GitHub Pages is an easy task. Just run it:
 npm run build:prod && npm run deploy:prod
 ```
 
+> [!IMPORTANT]  
+> If you're deploying outside the root path (example: youruser.github.io/gambiconf), you need to set the environment variable `BASE_PATH` to the target base path (example: `/gambiconf`).
+
 ### Staging
 
 We have a [staging repository/environmnet](https://github.com/gambiconf/website-staging).

--- a/src/components/Seo.svelte
+++ b/src/components/Seo.svelte
@@ -1,16 +1,16 @@
 <meta
   name="description"
-  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de novembro"
+  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de Novembro"
 />
 
 <meta
   property="og:title"
-  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de novembro"
+  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de Novembro"
 />
 <meta property="og:url" content="https://gambiconf.dev/" />
 <meta
   property="og:description"
-  content="O evento GambiConf é um ambiente amistoso, de boa convivência, inclusivo e livre de intimidação, onde todas as pessoas são bem-vindas e a civilidade é exigida."
+  content="A GambiConf é um evento de tech onde buscamos assuntos fora da caixa, como projetos pessoais, soluções inusitadas para problemas reais, ou apenas algo divertido"
 />
 <meta property="og:image" content="https://gambiconf.dev/favicon.png" />
 <meta property="og:type" content="website" />
@@ -22,12 +22,12 @@
 <meta name="twitter:card" content="summary" />
 <meta
   name="twitter:title"
-  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de novembro"
+  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de Novembro"
 />
 <meta name="twitter:url" content="https://gambiconf.dev/" />
 <meta
   name="twitter:description"
-  content="O evento GambiConf é um ambiente amistoso, de boa convivência, inclusivo e livre de intimidação, onde todas as pessoas são bem-vindas e a civilidade é exigida."
+  content="A GambiConf é um evento de tech onde buscamos assuntos fora da caixa, como projetos pessoais, soluções inusitadas para problemas reais, ou apenas algo divertido"
 />
 <meta name="twitter:image" content="https://gambiconf.dev/favicon.png" />
 <meta

--- a/src/components/Seo.svelte
+++ b/src/components/Seo.svelte
@@ -27,7 +27,7 @@
 <meta name="twitter:url" content="https://gambiconf.dev/" />
 <meta
   name="twitter:description"
-  content="A GambiConf é um evento de tech onde buscamos assuntos fora da caixa, como projetos pessoais, soluções inusitadas para problemas reais, ou apenas algo divertido"
+  content="Evento de computação onde buscamos temas ousados e divertidos!"
 />
 <meta name="twitter:image" content="https://gambiconf.dev/favicon.png" />
 <meta

--- a/src/components/Seo.svelte
+++ b/src/components/Seo.svelte
@@ -1,37 +1,37 @@
 <meta
   name="description"
-  content="GambiConf - The Blow Your Mind Conference / September 3 and 10"
+  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de novembro"
 />
 
 <meta
   property="og:title"
-  content="GambiConf - The Blow Your Mind Conference / September 3 and 10"
+  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de novembro"
 />
 <meta property="og:url" content="https://gambiconf.dev/" />
 <meta
   property="og:description"
-  content="GambiConf is a tech conference that's gonna blow your mind! This is a multilingual conference, not limited to a specific technology. We focus on the purpose of the presented projects, their unique nature, and what one can learn from a random, very unusual, idea."
+  content="O evento GambiConf é um ambiente amistoso, de boa convivência, inclusivo e livre de intimidação, onde todas as pessoas são bem-vindas e a civilidade é exigida."
 />
 <meta property="og:image" content="https://gambiconf.dev/favicon.png" />
 <meta property="og:type" content="website" />
 <meta
   property="og:image:alt"
-  content="GambiConf's mascot. An anthropomorphic orange monkey using a neck scarf with the flag of the European Union"
+  content="O mascote da GambiConf, um mico-leão dourado antropomórfico."
 />
 
 <meta name="twitter:card" content="summary" />
 <meta
   name="twitter:title"
-  content="GambiConf - The Blow Your Mind Conference / September 3 and 10"
+  content="GambiConf - The Blow Your Mind Conference / 02 e 03 de novembro"
 />
 <meta name="twitter:url" content="https://gambiconf.dev/" />
 <meta
   name="twitter:description"
-  content="GambiConf is a tech conference that's gonna blow your mind! This is a multilingual conference, not limited to a specific technology. We focus on the purpose of the presented projects, their unique nature, and what one can learn from a random, very unusual, idea."
+  content="O evento GambiConf é um ambiente amistoso, de boa convivência, inclusivo e livre de intimidação, onde todas as pessoas são bem-vindas e a civilidade é exigida."
 />
 <meta name="twitter:image" content="https://gambiconf.dev/favicon.png" />
 <meta
   name="twitter:image:alt"
-  content="GambiConf's mascot. An anthropomorphic orange monkey using a neck scarf with the flag of the European Union"
+  content="O mascote da GambiConf, um mico-leão dourado antropomórfico."
 />
 <meta name="twitter:creator" content="@gambiconf" />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,7 +6,7 @@ const mapEnvironmentToBasePath = {
   production: "",
   staging: "/website-staging",
 };
-const basePath = mapEnvironmentToBasePath[environment];
+const basePath = mapEnvironmentToBasePath[environment] ?? process.env.BASE_PATH;
 console.warn(`Unknown environment: "${environment}"`);
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -35,9 +35,6 @@ const config = {
       base: basePath,
     },
     adapter: staticAdapter(),
-    paths: {
-      base: process.argv.includes('dev') ? '' : process.env.BASE_PATH,
-    },
   },
 };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -34,10 +34,10 @@ const config = {
     paths: {
       base: basePath,
     },
-    adapter: staticAdapter({
-      fallback: "index.html",
-    }),
-    prerender: { entries: [] },
+    adapter: staticAdapter(),
+    paths: {
+			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
+		}
   },
 };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -36,8 +36,8 @@ const config = {
     },
     adapter: staticAdapter(),
     paths: {
-			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
-		}
+      base: process.argv.includes('dev') ? '' : process.env.BASE_PATH,
+    },
   },
 };
 


### PR DESCRIPTION
This PR removes the fallback to index.html, thus disabling the SPA mode so the pages can be prerendered.
The prerender is needed for getting the embed for platforms like Discord or Telegram.

Note that, because of this change, it's now needed to set the BASE_PATH variable on build to deploy on Github Pages, [as it's stated on README.md](https://github.com/gambiconf/gambiconf.github.io/commit/18ff742b531ef179265bf0fee83e65c9e59303b1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42).

It also changes the texts is Seo.svelte to portuguese, as requested by @macabeus 