### PR TITLE
row-what-is-gambiconf: fix `link-talk-satellite` url

### DIFF
--- a/src/components/RowWhatIsGambiConf.svelte
+++ b/src/components/RowWhatIsGambiConf.svelte
@@ -18,7 +18,7 @@
       <p>
         <Overlay id="row-what-is-gambiconf--body-paragraph-2">
           <Link l10n="link-talk-water" href="https://www.youtube.com/watch?v=UWiXNTdmL2Q" />
-          <Link l10n="link-talk-satellite" href="https://www.youtube.com/watch?v=UWiXNTdmL2Q" />
+          <Link l10n="link-talk-satellite" href="https://www.youtube.com/watch?v=6msRiv4PJVk" />
         </Overlay>
       </p>
 


### PR DESCRIPTION
Both links were the same, the second link was incorrect. 
Correct address for the "satellite reverse engineering" talk has been fixed. ✅