### PR TITLE
add financial report link in the main website to the conta aberta site

### DIFF
--- a/l10n/en.ftl
+++ b/l10n/en.ftl
@@ -7,6 +7,7 @@ header--about = About
 header--cfp = CFP
 header--album = Album
 header--schedule = Schedule
+header--financial-report = Financial Report
 
 ## Hero
 

--- a/l10n/pt.ftl
+++ b/l10n/pt.ftl
@@ -7,6 +7,7 @@ header--about = Sobre
 header--cfp = CFP
 header--album = Album
 header--schedule = Agenda
+header--financial-report = Prestação de Contas
 
 ## Hero
 

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -15,6 +15,7 @@
     <Link href="/" variant="secondary"><Localized id="header--home" /></Link>
     <Link href="/#about" variant="secondary"><Localized id="header--about" /></Link>
     <Link href="/cfp" variant="secondary"><Localized id="header--cfp" /></Link>
+    <Link href="https://contaaberta.info/@gambiconf" target="_blank" variant="secondary"><Localized id="header--financial-report" /></Link>
     <LanguageSwitcher />
     <ThemeSwitcher />
   </nav>


### PR DESCRIPTION
<center>
<img src="https://github.com/user-attachments/assets/46aee18b-7c22-4d10-8693-308b968ebbc3" />
</center>

This pull request adds a new link titled "Financial Report" to the site header. The link directs users to the external platform "Conta Aberta," where they can view the event's financial details.

This provides an easy access to the event's financial report for attendees and interested parties. It aligns with the goal of maintaining open and clear communication regarding the event's finances.